### PR TITLE
Improve compile error messages even further

### DIFF
--- a/src/main/scala/de/heikoseeberger/demophantomtypes/Hacker.scala
+++ b/src/main/scala/de/heikoseeberger/demophantomtypes/Hacker.scala
@@ -23,6 +23,12 @@ object Hacker {
     sealed trait Caffeinated extends State
     sealed trait Decaffeinated extends State
   }
+  
+  @implicitNotFound("This hacker is in dire need of coffee!")
+  type IsCaffeinated[S <: State] = S =:= State.Caffeinated
+
+  @implicitNotFound("This hacker already had coffee and needs to do some hacking first.")
+  type IsDecaffeinated[S <: State] = S =:= State.Decaffeinated
 
   def caffeinated: Hacker[State.Caffeinated] = new Hacker
   def decaffeinated: Hacker[State.Decaffeinated] = new Hacker
@@ -31,12 +37,12 @@ object Hacker {
 class Hacker[S <: Hacker.State] private {
   import Hacker._
 
-  def hackOn(implicit ev: S =:= State.Caffeinated): Hacker[State.Decaffeinated] = {
+  def hackOn(implicit ev: IsCaffeinated[S]): Hacker[State.Decaffeinated] = {
     println("Hacking, hacking, hacking!")
     new Hacker
   }
 
-  def drinkCoffee(implicit ev: S =:= State.Decaffeinated): Hacker[State.Caffeinated] = {
+  def drinkCoffee(implicit ev: IsDecaffeinated[S]): Hacker[State.Caffeinated] = {
     println("Slurp ...")
     new Hacker
   }


### PR DESCRIPTION
This is a neat little trick to get exactly the error message you want, hiding the actual `=:=` implementation from the User.
I'm not sure who came up with this first, I discovered it a couple of months back while doing some [shapeless experiments](https://gist.github.com/knutwalker/da7da4262d1fc15a1ec4#file-pluck-scala-L13-L14) and I haven't really seen it around :-)

Here's how it looks:

``` scala
scala> Hacker.caffeinated.hackOn.hackOn
<console>:14: error: This hacker is in dire need of coffee!
       Hacker.caffeinated.hackOn.hackOn
                                 ^

scala> Hacker.decaffeinated.drinkCoffee.drinkCoffee
<console>:14: error: This hacker already had coffee and needs to do some hacking first.
       Hacker.decaffeinated.drinkCoffee.drinkCoffee
                                        ^
```

At any rate, great write-up on phantom types.
